### PR TITLE
Add usage overview to notebook

### DIFF
--- a/DrawMicromodels.ipynb
+++ b/DrawMicromodels.ipynb
@@ -1,6 +1,18 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Usage and Functionality\n",
+    "This notebook generates synthetic micromodel images composed of bead-like structures.\n",
+    "Run the cells sequentially to create TIFF images and HDF5 datasets in the `image_output/` directory under the current working directory.\n",
+    "You can adjust parameters such as `rad`, `stride`, and deviation values in each code cell to create different geometries.\n",
+    "Later sections demonstrate more complex models including high-permeability regions and overlays of large beads.\n",
+    "Ensure required Python packages (`matplotlib`, `numpy`, `h5py`, `skimage`, and `Pillow`) are installed before execution.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {


### PR DESCRIPTION
## Summary
- add detailed usage info to the notebook

## Testing
- `python -m json.tool DrawMicromodels.ipynb | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_683f08c979288329aebb31684cf49003